### PR TITLE
Fixed package.json name value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tfjs virtual background PoC",
+  "name": "tfjs-virtual-background-PoC",
   "version": "0.1.0",
   "author": {
     "name": "Sergio Carracedo",


### PR DESCRIPTION
With the original name I get:

```
yarn install v1.17.3
error package.json: Name contains illegal characters
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```